### PR TITLE
Accept only hex when creating the color picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ new Vue({
 
 ### ES6
 ```js
-import Photoshop from 'vue-color/src/Photoshop.vue'
+import { Photoshop } from 'vue-color'
 
 new Vue({
   components: {
-    PulseLoader
+    'photoshop-picker': Photoshop
   }
 })
 ```

--- a/src/mixin/color.js
+++ b/src/mixin/color.js
@@ -30,7 +30,10 @@ export default {
   created () {
     // console.log(this.colors)
     /*
-      enforce the colorChange in case only hex is given it will create every data needed
+      Enforce the colorChange in case only HEX value is given.
+      Guarantees that HEX value is uppercase and other values such
+      as HSL or HSV exists and reflect the HEX value
+      TODO accept any kind of color value, HEX, RGBA, HSL and others
     */
     this.colors = _colorChange(this.colors)
   },

--- a/src/mixin/color.js
+++ b/src/mixin/color.js
@@ -1,35 +1,42 @@
 import tinycolor from 'tinycolor2'
 
+function _colorChange (data, oldHue) {
+  if (data.a && data.a > 1) {
+    data.a = 1
+  }
+
+  var color = data.hex ? tinycolor(data.hex) : tinycolor(data)
+  var hsl = color.toHsl()
+  var hsv = color.toHsv()
+  if (hsl.s === 0) {
+    hsl.h = oldHue || 0
+    hsv.h = oldHue || 0
+  }
+  return {
+    hsl: hsl,
+    hex: color.toHexString().toUpperCase(),
+    rgba: color.toRgb(),
+    hsv: hsv,
+    oldHue: data.h || oldHue || hsl.h,
+    source: data.source,
+    a: data.a
+  }
+}
+
 export default {
   props: {
     colors: Object
   },
   created () {
     // console.log(this.colors)
-    this.colors.hex = this.colors.hex.toUpperCase()
+    /*
+      enforce the colorChange in case only hex is given it will create every data needed
+    */
+    this.colors = _colorChange(this.colors)
   },
   methods: {
     colorChange (data, oldHue) {
-      if (data.a && data.a > 1) {
-        data.a = 1
-      }
-
-      var color = data.hex ? tinycolor(data.hex) : tinycolor(data)
-      var hsl = color.toHsl()
-      var hsv = color.toHsv()
-      if (hsl.s === 0) {
-        hsl.h = oldHue || 0
-        hsv.h = oldHue || 0
-      }
-      this.colors = {
-        hsl: hsl,
-        hex: color.toHexString().toUpperCase(),
-        rgba: color.toRgb(),
-        hsv: hsv,
-        oldHue: data.h || oldHue || hsl.h,
-        source: data.source,
-        a: data.a
-      }
+      this.colors = _colorChange(data, oldHue)
     },
     isValidHex (hex) {
       return tinycolor(hex).isValid()

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -1,7 +1,7 @@
 var config = require('./webpack.config.js')
 
 config.entry = {
-  'vue-color': './src/index.js',
+  'vue-color': './src/index.js'
 }
 
 config.output = {
@@ -9,6 +9,5 @@ config.output = {
   library: 'VueColor',
   libraryTarget: 'umd'
 }
-
 
 module.exports = config


### PR DESCRIPTION
I was needing this to work in my project and I think it's nice to have this option. If you only define the hex value in the colors prop it won't work, since the colors mixin need the other values which are calculated on change. I got your function that did the recalculation(colorChange method) and move it to a function and reuse it in the created function. I did a simple test and it worked fine. Feel free to accept or not, I was going to open a issue but since it's simple, one PR is fine IMO. Thank you for the vue-color. Feel free to contact me if necessary.