### PR TITLE
separate class from binding class

### DIFF
--- a/src/components/common/Hue.vue
+++ b/src/components/common/Hue.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['vue-color__c-hue', directionClass]">
+  <div class="vue-color__c-hue" :class="directionClass">
     <div class="vue-color__c-hue__container" v-el:container
       @mousedown="handleMouseDown"
       @touchmove="handleChange"


### PR DESCRIPTION
because the error is displayed:

vue.min.js:6 Uncaught InvalidCharacterError: Failed to execute 'add' on 'DOMTokenList': The token provided ('[object Object]') contains HTML space characters, which are not valid in tokens.