### PR TITLE
Sort prod and env configs out

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -4,8 +4,8 @@ var webpack = require('webpack')
 var config = require('../config')
 var proxyMiddleware = require('http-proxy-middleware')
 var webpackConfig = process.env.NODE_ENV === 'testing'
-  ? require('./webpack.prod.conf')
-  : require('./webpack.dev.conf')
+  ? require('./webpack.dev.conf')
+  : require('./webpack.prod.conf')
 
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port


### PR DESCRIPTION
I had troubles running the `npm run dev`, I kept getting `Cannot GET /`. When I looked at the config, I found it weird that the `prod` config was being loaded unless explicitly `NODE_ENV` was set to `testing`. I’m reverting that on this PR.

However, I might be wrong on this, and if so, I would love to know more about it, please. :) Thanks!