### PR TITLE
Replace $dispatch with $emit

### DIFF
--- a/src/components/Photoshop.vue
+++ b/src/components/Photoshop.vue
@@ -99,10 +99,10 @@ export default {
       }
     },
     handleAccept () {
-      this.$dispatch('ok')
+      this.$emit('ok')
     },
     handleCancel () {
-      this.$dispatch('cancel')
+      this.$emit('cancel')
     }
   }
 


### PR DESCRIPTION
Just noticed that `Photoshop.vue` uses `$dispatch` method, which has been deprecated since Vue.js 2.0. The use of `$dispatch` is resulting in the below error in the console when you click the "OK" and "Cancel" buttons. Although this is not a critical bug or anything, I just thought people would be confused to see such error, so I've replaced them with the simple `$emit` API, which properly triggers the `console.log('ok')` and `console.log('cancel')` inside `App.vue`. 

### BEFORE

![screen shot 2016-12-13 at 10 18 17](https://cloud.githubusercontent.com/assets/1957801/21123817/5a6bfe5a-c11e-11e6-92c3-0b07a8962ecd.jpg)

### AFTER

![screen shot 2016-12-13 at 10 18 03](https://cloud.githubusercontent.com/assets/1957801/21123816/5a661184-c11e-11e6-9c80-e9fdeb56a586.jpg)

ref: [vuejs/vue 2.0 Changes](https://github.com/vuejs/vue/issues/2873)