### PR TITLE
Fix Issue #40: Alpha is set back to 1 when the colour changes

### DIFF
--- a/src/mixin/color.js
+++ b/src/mixin/color.js
@@ -5,7 +5,13 @@ function _colorChange (data, oldHue) {
     data.a = 1
   }
 
-  var color = data.hex ? tinycolor(data.hex) : tinycolor(data)
+  var color
+  if (data.hex) {
+    color = tinycolor(data.hex)
+    color.setAlpha(data.a)
+  } else {
+    color = tinycolor(data)
+  }
   var hsl = color.toHsl()
   var hsv = color.toHsv()
   if (hsl.s === 0) {

--- a/src/mixin/color.js
+++ b/src/mixin/color.js
@@ -8,7 +8,7 @@ function _colorChange (data, oldHue) {
   var color
   if (data.hex) {
     color = tinycolor(data.hex)
-    color.setAlpha(data.a)
+    color.setAlpha(data.a || 1)
   } else {
     color = tinycolor(data)
   }


### PR DESCRIPTION
This fixes: https://github.com/xiaokaike/vue-color/issues/40

The issue arose when using tinycolor to parse hex values.  Since a hex string has no alpha value, tinycolor will always set an alpha of 1.  Instead, we should set the alpha value that was passed in with the `data`.