### PR TITLE
Bugfix: avoid exception when dragging cursor to the edge of window

### DIFF
--- a/src/components/common/Alpha.vue
+++ b/src/components/common/Alpha.vue
@@ -42,7 +42,10 @@ export default {
       !skip && e.preventDefault()
       var container = this.$refs.container
       var containerWidth = container.clientWidth
-      var left = (e.pageX || e.touches[0].pageX) - (container.getBoundingClientRect().left + window.pageXOffset)
+
+      var xOffset = container.getBoundingClientRect().left + window.pageXOffset
+      var pageX = e.pageX || (e.touches ? e.touches[0].pageX : 0)
+      var left = pageX - xOffset
 
       var a
       if (left < 0) {

--- a/src/components/common/Hue.vue
+++ b/src/components/common/Hue.vue
@@ -54,8 +54,14 @@ export default {
       var container = this.$refs.container
       var containerWidth = container.clientWidth
       var containerHeight = container.clientHeight
-      var left = (e.pageX || e.touches[0].pageX) - (container.getBoundingClientRect().left + window.pageXOffset)
-      var top = (e.pageY || e.touches[0].pageY) - (container.getBoundingClientRect().top + window.pageYOffset)
+
+      var xOffset = container.getBoundingClientRect().left + window.pageXOffset
+      var yOffset = container.getBoundingClientRect().top + window.pageYOffset
+      var pageX = e.pageX || (e.touches ? e.touches[0].pageX : 0)
+      var pageY = e.pageY || (e.touches ? e.touches[0].pageY : 0)
+      var left = pageX - xOffset
+      var top = pageY - yOffset
+
       var h
       var percent
 

--- a/src/components/common/Saturation.vue
+++ b/src/components/common/Saturation.vue
@@ -46,8 +46,13 @@ export default {
       var container = this.$refs.container
       var containerWidth = container.clientWidth
       var containerHeight = container.clientHeight
-      var left = (e.pageX || e.touches[0].pageX) - (container.getBoundingClientRect().left + window.pageXOffset)
-      var top = (e.pageY || e.touches[0].pageY) - (container.getBoundingClientRect().top + window.pageYOffset)
+
+      var xOffset = container.getBoundingClientRect().left + window.pageXOffset
+      var yOffset = container.getBoundingClientRect().top + window.pageYOffset
+      var pageX = e.pageX || (e.touches ? e.touches[0].pageX : 0)
+      var pageY = e.pageY || (e.touches ? e.touches[0].pageY : 0)
+      var left = pageX - xOffset
+      var top = pageY - yOffset
 
       if (left < 0) {
         left = 0


### PR DESCRIPTION
## Summary

This PR fixes the bug where some of the common components cause an exception when clicking and dragging out to the edge of the window.

## How to reproduce

1. Visit the [demo page](https://xiaokaike.github.io/vue-color/)
1. Click inside the saturation/hue/alpha area of any of the container components
1. Keep the mouse key down and drag it far out beyond the component to the edge of the browser window 

![apr-21-2017 23-12-49](https://cloud.githubusercontent.com/assets/1957801/25281502/92961a42-26e8-11e7-8864-7233dea68014.gif)

## Result

The exception no longer occurs.

![apr-21-2017 23-21-24](https://cloud.githubusercontent.com/assets/1957801/25281778/56fbeefc-26e9-11e7-9d76-98777372b1c3.gif)
