### PR TITLE
remove trailing spaces to make lint script pass

### DIFF
--- a/src/components/common/EditableInput.vue
+++ b/src/components/common/EditableInput.vue
@@ -53,7 +53,7 @@ export default {
         this.$emit('change', data)
       }
     },
-    // **** unused 
+    // **** unused
     // handleBlur (e) {
     //   console.log(e)
     // },
@@ -79,7 +79,7 @@ export default {
         }
       }
     }
-    // **** unused 
+    // **** unused
     // handleDrag (e) {
     //   console.log(e)
     // },


### PR DESCRIPTION
currently `npm run release` fails with:
```
/vue-color/src/components/common/EditableInput.vue
  56:19  error  Trailing spaces not allowed  no-trailing-spaces
  82:19  error  Trailing spaces not allowed  no-trailing-spaces
```