### PR TITLE
Remove unused property 'fields' in data in Chrome component

### DIFF
--- a/src/components/Chrome.vue
+++ b/src/components/Chrome.vue
@@ -105,7 +105,6 @@ export default {
   },
   data () {
     return {
-      fields: ['hex', 'rgba', 'hsla'],
       fieldsIndex: 0,
       highlight: false
     }


### PR DESCRIPTION
The property 'fields' seems unused.
And the property causes the warning in a case using vue-color with [baianat/vee-validate](https://github.com/baianat/vee-validate), so this PR also solves the problem.

* https://github.com/xiaokaike/vue-color/issues/84