### PR TITLE
Disable webpack global polyfill

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -69,5 +69,10 @@ module.exports = {
       /handsontable\.(full\.)?js/,
       /plotly\.js/
     ]
+  },
+
+  node: {
+    // prevent webpack from injecting an global polyfill that includes Function(return this) and eval(this)
+    global: false
   }
 }


### PR DESCRIPTION
Vue requires an global polyfill for the full build (with compiler) to
compile templates in runtime. Since this project compiles templates
during build with vue-loader, this polyfill is not needed. This will fix
errors in CSP environments that do not allow 'unsafe-eval'.