### PR TITLE
Enforce border-radius for active swatch pickers

### DIFF
--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -110,7 +110,7 @@ export default {
   cursor: pointer;
   height: 12px;
 }
-.vc-slider-swatch-picker--active {
+.vc-slider-swatch:nth-child(n) .vc-slider-swatch-picker.vc-slider-swatch-picker--active {
   transform: scaleY(1.8);
   border-radius: 3.6px/2px;
 }


### PR DESCRIPTION
Ensure precedence over conflicting border-radius rules for .vc-slider-swatch:[first/last]-child .vc-slider-swatch-picker.

These rules otherwise cause sharp borders on the inside when an outer swatch picker is active. The problem can be seen in the demo and even in intro.png.