### PR TITLE
Fixed HTML attribute for presetColors in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ In some cases you can give the component a predefined set of colors with the pro
 <sketch-picker 
   @input="updateValue"
   :value="colors"
-  :presetColors="[ 
+  :preset-colors="[ 
     '#f00', '#00ff00', '#00ff0055', 'rgb(201, 76, 76)', 'rgba(0,0,255,1)', 'hsl(89, 43%, 51%)', 'hsla(89, 43%, 51%, 0.6)'
   ]"
 ></sketch-picker>


### PR DESCRIPTION
HTML attributes are case-insensitive, so the property was passed as lowercase and didn't work.
The solution, provided by Vue, is to change the attribute to kebab-case and it will be automatically converted to camelCase.

![image](https://user-images.githubusercontent.com/3891092/78554728-f6465800-780b-11ea-907d-6c9563b47ea0.png)
