### PR TITLE
fix: add outline none to picker-wrap

### DIFF
--- a/src/components/common/BaseSlider.vue
+++ b/src/components/common/BaseSlider.vue
@@ -222,6 +222,7 @@ onUnmounted(() => {
 .picker-wrap {
   position: absolute;
   z-index: 2;
+  outline: none;
 }
 .picker {
   width: 4px;

--- a/src/components/common/SaturationSlider.vue
+++ b/src/components/common/SaturationSlider.vue
@@ -239,6 +239,7 @@ onUnmounted(() => {
 .picker-wrap {
   cursor: pointer;
   position: absolute;
+  outline: none;
 }
 
 .picker {


### PR DESCRIPTION
Without `outline: none` to the `.picker-wrap`, following outline appears on the thumb.

<img width="240" height="251" alt="image" src="https://github.com/user-attachments/assets/cbc05ea8-b953-45a9-bc15-364f15b2c7a5" />

Outline is added by the browser agent style otherwise
```
:focus-visible {
    outline: -webkit-focus-ring-color auto 1px;
}
```